### PR TITLE
chore: move pod trunk command directly to publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,6 @@ jobs:
           pod install --project-directory=Example
           set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/KenticoKontentDelivery.xcworkspace -scheme KenticoKontentDelivery-Example -sdk iphonesimulator -destination 'name=iPhone 11' ONLY_ACTIVE_ARCH=NO | xcpretty
       - name: Publish Cocoapod
-        run: chmod +x scripts/push.sh && scripts/push.sh
+        run: pod trunk push
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-pod trunk push


### PR DESCRIPTION
chore: move pod trunk command directly to publish action